### PR TITLE
Adds pills to psychologist and fixes some moodlet text

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -1,6 +1,6 @@
 /datum/mood_event/high
 	mood_change = 6
-	description = "<span class='nicegreen'>Woooow duudeeeeee...I'm tripping baaalls...</span>\n"
+	description = "<span class='nicegreen'>Woooow duudeeeeee... I'm tripping baaalls...</span>\n"
 
 /datum/mood_event/smoked
 	description = "<span class='nicegreen'>I have had a smoke recently.</span>\n"
@@ -30,7 +30,7 @@
 	mood_change = -8
 
 /datum/mood_event/withdrawal_severe/add_effects(drug_name)
-	description = "<span class='boldwarning'>Oh god I need some [drug_name]</span>\n"
+	description = "<span class='boldwarning'>Oh god, I need some [drug_name]</span>\n"
 
 /datum/mood_event/withdrawal_critical
 	mood_change = -10

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -45,7 +45,7 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/delam //SM delamination
-	description = "<span class='boldwarning'>Those God damn engineers can't do anything right...</span>\n"
+	description = "<span class='boldwarning'>Those goddamn engineers can't do anything right...</span>\n"
 	mood_change = -2
 	timeout = 2400
 
@@ -153,7 +153,7 @@
 	timeout = 1200
 
 /datum/mood_event/spooked
-	description = "<span class='warning'>The rattling of those bones...It still haunts me.</span>\n"
+	description = "<span class='warning'>The rattling of those bones... It still haunts me.</span>\n"
 	mood_change = -4
 	timeout = 2400
 
@@ -174,7 +174,7 @@
 	mood_change = -6
 
 /datum/mood_event/surgery
-	description = "<span class='boldwarning'>HE'S CUTTING ME OPEN!!</span>\n"
+	description = "<span class='boldwarning'>THEY'RE CUTTING ME OPEN!!</span>\n"
 	mood_change = -8
 
 //End unused

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -50,7 +50,7 @@
 	mood_change = -5
 
 /datum/mood_event/disgusted
-	description = "<span class='boldwarning'>Oh god that's disgusting...</span>\n"
+	description = "<span class='boldwarning'>Oh god, that's disgusting...</span>\n"
 	mood_change = -8
 
 /datum/mood_event/disgust/bad_smell

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -413,6 +413,31 @@
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/pill/neurine(src)
 
+///////////////////////////////////////// Psychologist inventory pillbottles
+/obj/item/storage/pill_bottle/happinesspsych
+	name = "happiness pills"
+	desc = "Contains pills used as a last resort means to temporarily stabilize depression and anxiety. WARNING: side effects may include slurred speech, drooling, and severe addiction."
+
+/obj/item/storage/pill_bottle/happinesspsych/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/happinesspsych(src)
+
+/obj/item/storage/pill_bottle/lsdpsych
+	name = "mindbreaker toxin pills"
+	desc = "!FOR THERAPEUTIC USE ONLY! Contains pills used to alleviate the symptoms of Reality Dissociation Syndrome."
+
+/obj/item/storage/pill_bottle/lsdpsych/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/lsdpsych(src)
+
+/obj/item/storage/pill_bottle/paxpsych
+	name = "pax pills"
+	desc = "Contains pills used to temporarily pacify patients that are deemed a harm to themselves or others."
+
+/obj/item/storage/pill_bottle/paxpsych/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/paxpsych(src)
+
 /////////////
 //Organ Box//
 /////////////

--- a/code/modules/jobs/job_types/psychologist.dm
+++ b/code/modules/jobs/job_types/psychologist.dm
@@ -30,6 +30,8 @@
 	pda_slot = ITEM_SLOT_BELT
 	l_hand = /obj/item/clipboard
 
+	backpack_contents = list(/obj/item/storage/pill_bottle/mannitol, /obj/item/storage/pill_bottle/psicodine, /obj/item/storage/pill_bottle/paxpsych, /obj/item/storage/pill_bottle/happinesspsych, /obj/item/storage/pill_bottle/lsdpsych)
+
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -214,6 +214,29 @@
 	icon_state = "pill9"
 	color = "#454545"
 	list_reagents = list(/datum/reagent/mutationtoxin/shadow = 1)
+
+///////////////////////////////////////// Psychologist inventory pills
+/obj/item/reagent_containers/pill/happinesspsych
+	name = "mood stabilizer pill"
+	desc = "Used to temporarily alleviate anxiety and depression, take only as prescribed."
+	list_reagents = list(/datum/reagent/drug/happiness = 5)
+	icon_state = "pill_happy"
+	roundstart = TRUE
+
+/obj/item/reagent_containers/pill/paxpsych
+	name = "pacification pill"
+	desc = "Used to temporarily suppress violent, homicidal, or suicidal behavior in patients."
+	list_reagents = list(/datum/reagent/pax = 5)
+	icon_state = "pill12"
+	roundstart = TRUE
+
+/obj/item/reagent_containers/pill/lsdpsych
+	name = "antipsychotic pill"
+	desc = "Talk to your healthcare provider immediately if hallucinations worsen or new hallucinations emerge."
+	list_reagents = list(/datum/reagent/toxin/mindbreaker = 5)
+	icon_state = "pill14"
+	roundstart = TRUE
+
 //////////////////////////////////////// drugs
 /obj/item/reagent_containers/pill/zoom
 	name = "zoom pill"


### PR DESCRIPTION
## About The Pull Request

This gives the Psychologist some pill bottles and fun flavor text for them in their backpack.

Mannitol - 50u X 7 pills
Psicodine - 10u X 7 pills
Pax - 5u X 5 pills
Happiness - 5u X 5 pills
Mindbreaker Toxin - 5u X 5 pills

## Why It's Good For The Game

This helps to establish that the Psychologist is allowed to possess and prescribe drugs to patients, while not giving him an insanely large amount of drugs roundstart. When the Psychologist runs out, he'll have to get Chemistry to resupply him.

Additionally, this might help newer players learn the usefulness of Mannitol, Psicodine, and Mindbreaker Toxin.

## Changelog
:cl:
add: The psychologist now starts every shift with a small supply of pills.
spellcheck: Fixed a few moodlet typos.
/:cl: