### PR TITLE
Makes accidents based on settings and not traits

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -439,29 +439,9 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	var/mob/living/carbon/human/H = quirk_holder
 	H?.cure_trauma_type(/datum/brain_trauma/severe/monophobia, TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/quirk/incontinent
-	name = "Incontinent"
-	desc = "For whatever reason, you have a hard time holding it. Opts you into the diaper usage system, and doubles the rate at which you have accidents."
-	mob_trait = TRAIT_INCONTINENT
-	value = 0
-	medical_record_text = "Patient is incontinent."
-	mood_quirk = TRUE
-
-/datum/quirk/incontinent/add()
-	. = ..()
-	SEND_SIGNAL(quirk_holder, COMSIG_DIAPERCHANGE, ckey(quirk_holder.mind.key))
-	quirk_holder.max_wetcontinence = 50
-	quirk_holder.max_messcontinence = 50
-
-/datum/quirk/incontinent/remove()
-	. = ..()
-	SEND_SIGNAL(quirk_holder, COMSIG_DIAPERCHANGE, ckey(quirk_holder.mind.key))
-	quirk_holder.max_wetcontinence = 100
-	quirk_holder.max_messcontinence = 100
-
 /datum/quirk/fullyincontinent
 	name = "Unaware"
-	desc = "You suffered damage to your sacral nerve system at some point. Opts you into the diaper usage system, and removes any indication that you need to go."
+	desc = "You suffered severe damage to your sacral nerve system at some point."
 	mob_trait = TRAIT_FULLYINCONTINENT
 	value = 0
 	medical_record_text = "Patient has suffered severe sacral nerve damage."
@@ -472,20 +452,6 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	SEND_SIGNAL(quirk_holder, COMSIG_DIAPERCHANGE, ckey(quirk_holder.mind.key))
 
 /datum/quirk/fullyincontinent/remove()
-	. = ..()
-	SEND_SIGNAL(quirk_holder, COMSIG_DIAPERCHANGE, ckey(quirk_holder.mind.key))
-
-/datum/quirk/diaperuse
-	name = "Diaper Wearer"
-	desc = "For whatever reason, you are kept in diapers- and use them."
-	mob_trait = TRAIT_DIAPERUSE
-	value = 0
-
-/datum/quirk/diaperuse/add()
-	. = ..()
-	SEND_SIGNAL(quirk_holder, COMSIG_DIAPERCHANGE, ckey(quirk_holder.mind.key))
-
-/datum/quirk/diaperuse/remove()
 	. = ..()
 	SEND_SIGNAL(quirk_holder, COMSIG_DIAPERCHANGE, ckey(quirk_holder.mind.key))
 
@@ -564,9 +530,10 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 			wheels.buckle_mob(quirk_holder)
 
 /datum/quirk/stinker
-	name = "Accident Prone"
-	desc = "Your bowels and bladder tend to fill up quicker than usual."
+	name = "Fast Metabolism"
+	desc = "You seem to need to go more often than others."
 	value = 0
 	mob_trait = TRAIT_STINKER
-	gain_text = null
-	lose_text = null
+	gain_text = "<span class='notice'>Your insides rumble ominously.</span>"
+	lose_text = "<span class='notice'>You feel less bloated!</span>"
+	medical_record_text = "Patient exhibits symptoms of an accelerated metabolism for food and drinks."

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/split_eye_colors = FALSE
 	var/datum/species/pref_species = new /datum/species/human()	//Mutant race
 	var/list/features = list("mcolor" = "FFFFFF", "mcolor2" = "FFFFFF", "mcolor3" = "FFFFFF", "tail_lizard" = "Smooth", "tail_human" = "None", "snout" = "Round", "horns" = "None", "horns_color" = "85615a", "ears" = "None", "wings" = "None", "wings_color" = "FFF", "frills" = "None", "deco_wings" = "None", "spines" = "None", "legs" = "Plantigrade", "insect_wings" = "Plain", "insect_fluff" = "None", "insect_markings" = "None", "arachnid_legs" = "Plain", "arachnid_spinneret" = "Plain", "arachnid_mandibles" = "Plain", "mam_body_markings" = list(), "mam_ears" = "None", "mam_snouts" = "None", "mam_tail" = "None", "mam_tail_animated" = "None", "xenodorsal" = "Standard", "xenohead" = "Standard", "xenotail" = "Xenomorph Tail", "taur" = "None", "genitals_use_skintone" = FALSE, "has_cock" = FALSE, "cock_shape" = DEF_COCK_SHAPE, "cock_length" = COCK_SIZE_DEF, "cock_diameter_ratio" = COCK_DIAMETER_RATIO_DEF, "cock_color" = "ffffff", "cock_taur" = FALSE, "has_balls" = FALSE, "balls_color" = "ffffff", "balls_shape" = DEF_BALLS_SHAPE, "balls_size" = BALLS_SIZE_DEF, "balls_cum_rate" = CUM_RATE, "balls_cum_mult" = CUM_RATE_MULT, "balls_efficiency" = CUM_EFFICIENCY, "has_breasts" = FALSE, "breasts_color" = "ffffff", "breasts_size" = BREASTS_SIZE_DEF, "breasts_shape" = DEF_BREASTS_SHAPE, "breasts_producing" = FALSE, "has_vag" = FALSE, "vag_shape" = DEF_VAGINA_SHAPE, "vag_color" = "ffffff", "has_womb" = FALSE, "has_butt" = FALSE, "butt_color" = "ffffff", "butt_size" = BUTT_SIZE_DEF, "balls_visibility" = GEN_VISIBLE_NO_UNDIES, "breasts_visibility"= GEN_VISIBLE_NO_UNDIES, "cock_visibility" = GEN_VISIBLE_NO_UNDIES, "vag_visibility" = GEN_VISIBLE_NO_UNDIES, "butt_visibility" = GEN_VISIBLE_NO_UNDIES, "ipc_screen" = "Sunburst", "ipc_antenna" = "None", "flavor_text" = "", "silicon_flavor_text" = "", "ooc_notes" = "", "meat_type" = "Mammalian", "body_model" = MALE, "body_size" = RESIZE_DEFAULT_SIZE, "color_scheme" = OLD_CHARACTER_COLORING)
-	var/accident_types = "Pee Only"
+	var/accident_types = "Opt Out"
 	var/accident_sounds = TRUE
 
 	var/custom_speech_verb = "default" //if your say_mod is to be something other than your races
@@ -1769,7 +1769,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						undie_color = sanitize_hexcolor(n_undie_color, 6)
 
 				if("accident_types")
-					accident_types = input(user, "Choose your accident preference.","Character Preference") as null|anything in list("Pee Only", "Poop Only", "Both")
+					accident_types = input(user, "Choose your accident preference.","Character Preference") as null|anything in list("Pee Only", "Poop Only", "Both", "Opt Out")
 
 				if("undershirt")
 					var/new_undershirt = input(user, "Choose your character's undershirt:", "Character Preference") as null|anything in GLOB.undershirt_list

--- a/code/modules/incon/diapers.dm
+++ b/code/modules/incon/diapers.dm
@@ -97,7 +97,7 @@
 /obj/item/diaper/attack(mob/living/carbon/human/M as mob, mob/usr as mob)
 	if(M == usr && HAS_TRAIT(M,TRAIT_NOCHANGESELF))
 		to_chat(usr, "<span class='warning'>You don't know how to change yourself!</span>")
-	else if(HAS_TRAIT(M,TRAIT_FULLYINCONTINENT) || HAS_TRAIT(M,TRAIT_INCONTINENT) || HAS_TRAIT(M,TRAIT_POTTYREBEL) || HAS_TRAIT(M,BABYBRAINED_TRAIT) || HAS_TRAIT(M,TRAIT_DIAPERUSE))
+	else if(src.client.prefs.accident_types != "Opt Out")
 		playsound(M.loc,'sound/effects/Diapertape.wav',50,1)
 		if(do_after_mob(usr,M))
 			M.DiaperChange(src)
@@ -105,12 +105,12 @@
 			M.DiaperAppearance()
 			if (findtext(M.brand, "hefters") != 0 || findtext(M.brand, "_thick") != 0)
 				M.heftersbonus = 100
-			if (findtext(M.brand, "trainer") != 0 || findtext(M.brand, "_trainer") != 0)
+			else if (findtext(M.brand, "trainer") != 0 || findtext(M.brand, "_trainer") != 0)
 				M.heftersbonus = -80
-			if (findtext(M.brand, "underwear") != 0 || findtext(M.brand, "_underwear") != 0)
-				M.heftersbonus = -140
-			else
-				M.heftersbonus = 0
+				else if (findtext(M.brand, "underwear") != 0 || findtext(M.brand, "_underwear") != 0)
+					M.heftersbonus = -140
+					else
+						M.heftersbonus = 0
 			Del()
 
 /obj/item/wetdiap/plain

--- a/code/modules/incon/diaperstatus.dm
+++ b/code/modules/incon/diaperstatus.dm
@@ -168,7 +168,7 @@
 		to_chat(src,"You can't poop, you're dead!")
 
 /mob/living/carbon/proc/PampUpdate()
-	if(stat != DEAD && (HAS_TRAIT(src,TRAIT_INCONTINENT) || HAS_TRAIT(src,TRAIT_FULLYINCONTINENT) || HAS_TRAIT(src,TRAIT_POTTYREBEL) || HAS_TRAIT(src,BABYBRAINED_TRAIT) || HAS_TRAIT(src,TRAIT_DIAPERUSE)) && src.client != null)
+	if(src.client.prefs.accident_types != "Opt Out")
 		if(src.client.prefs.accident_types != "Poop Only")
 			pee = pee + ((20 + rand(0, 10))/100) + (fluids / 3000)
 			if(HAS_TRAIT(src, TRAIT_STINKER))
@@ -549,7 +549,7 @@
 /mob/living/carbon/verb/Pee()
 	if(usr.client.prefs.accident_types != "Poop Only")
 		set category = "IC"
-	if((HAS_TRAIT(usr,TRAIT_INCONTINENT) || HAS_TRAIT(usr,TRAIT_POTTYREBEL) || HAS_TRAIT(usr,BABYBRAINED_TRAIT) || HAS_TRAIT(usr,TRAIT_DIAPERUSE)) && !HAS_TRAIT(usr,TRAIT_FULLYINCONTINENT) && pee >= max_wetcontinence/2)
+	if(src.client.prefs.accident_types != "Opt Out" && !HAS_TRAIT(usr,TRAIT_FULLYINCONTINENT) && pee >= max_wetcontinence/2)
 		on_purpose = 1
 		Wetting()
 	else
@@ -558,7 +558,7 @@
 /mob/living/carbon/verb/Poop()
 	if(usr.client.prefs.accident_types != "Pee Only")
 		set category = "IC"
-	if((HAS_TRAIT(usr,TRAIT_INCONTINENT) || HAS_TRAIT(usr,TRAIT_POTTYREBEL) || HAS_TRAIT(usr,BABYBRAINED_TRAIT) || HAS_TRAIT(usr,TRAIT_DIAPERUSE)) && !HAS_TRAIT(usr,TRAIT_FULLYINCONTINENT) && poop >= max_messcontinence/2)
+	if(src.client.prefs.accident_types != "Opt Out" && !HAS_TRAIT(usr,TRAIT_FULLYINCONTINENT) && poop >= max_messcontinence/2)
 		on_purpose = 1
 		Pooping()
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Setting to opt out of the metabolism system/accidents
remove: Trait based diapering
add: Setting based diapering
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
