### PR TITLE
Two New Chems and Toilet Fix

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -143,7 +143,12 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/painful_medicine
-	description = "<span class='warning'>Medicine may be good for me but right now it stings like hell.</span>\n"
+	description = "<span class='warning'>Medicine may be good for me, but right now it stings like hell.</span>\n"
+	mood_change = -5
+	timeout = 1 MINUTES
+
+/datum/mood_event/gross_medicine
+	description = "<span class='warning'>Medicine may be good for me, but it sure doesn't taste like it.</span>\n"
 	mood_change = -5
 	timeout = 1 MINUTES
 

--- a/code/modules/incon/diaperstatus.dm
+++ b/code/modules/incon/diaperstatus.dm
@@ -108,9 +108,6 @@ var/database/db = new("code/modules/incon/InconFlavortextDB.db")
 		src.visible_message(FlavortextQueryResponse["othersmessage"],FlavortextQueryResponse["selfmessage"])
 
 /mob/living/carbon/proc/Wetting()
-
-
-
 	if (pee > 0 && stat != DEAD && src.client.prefs != "Poop Only") //this checks if the player actually needs to pee, is alive, and has pee enabled
 		needpee = 0	//if we make it this far, we clear the "needpee" flag - we're now peeing
 
@@ -118,38 +115,38 @@ var/database/db = new("code/modules/incon/InconFlavortextDB.db")
 		if(src.client.prefs.accident_sounds == TRUE)
 			playsound(loc, 'sound/effects/pee-diaper.wav', 50, 1)
 
-		//if the player is on a potty or toilet at the time they pee, they're rewarded with some extra continence
+		//Next we check if the player is on a potty or toilet at the time they pee and, if so, they're rewarded with some extra continence
 		if (istype(src.buckled,/obj/structure/potty) || istype(src.buckled,/obj/structure/toilet))
 			if (max_wetcontinence < 100)
 				max_wetcontinence++
-
-		//if the amount of pee inside a player is higher than the max continence, we knock it down to the max continence
-		if(pee > max_wetcontinence)
-			pee = max_wetcontinence
-
-		//this block of code allows people to pee on the floor if they're nude (in the future)
-		if(ishuman(src))
-			var/mob/living/carbon/human/H = src
-			if(H.hidden_underwear == TRUE || H.underwear == "Nude")
-				pee = 0
-				new /obj/effect/decal/cleanable/waste/peepee(loc)
-
-
-		//this block updates the wetness of the diaper
-		//
-		//if the "wetness" of the diaper won't be overflowing, even with the pee about to be added, it's added like normal
-		//otherwise, the wetness of the diaper is maxed, and a pee puddle is spawned on the floor
-		//
-		//if leaking occurs, the player is penalized with an extra reduction in continence, unlesss they're already under 25% continent
-
-		if(wetness + pee < 200 + heftersbonus)
-			wetness = wetness + pee
-			pee = 0
 		else
-			wetness = 200 + heftersbonus
-			new /obj/effect/decal/cleanable/waste/peepee(loc)
-		if(max_wetcontinence > 25)
-			max_wetcontinence-=1
+			//if the amount of pee inside a player is higher than the max continence, we knock it down to the max continence
+			if(pee > max_wetcontinence)
+				pee = max_wetcontinence
+
+			//this block of code allows people to pee on the floor if they're nude (in the future)
+			if(ishuman(src))
+				var/mob/living/carbon/human/H = src
+				if(H.hidden_underwear == TRUE || H.underwear == "Nude")
+					pee = 0
+					new /obj/effect/decal/cleanable/waste/peepee(loc)
+
+
+			//this block updates the wetness of the diaper
+			//
+			//if the "wetness" of the diaper won't be overflowing, even with the pee about to be added, it's added like normal
+			//otherwise, the wetness of the diaper is maxed, and a pee puddle is spawned on the floor
+			//
+			//if leaking occurs, the player is penalized with an extra reduction in continence, unlesss they're already under 25% continent
+
+			if(wetness + pee < 200 + heftersbonus)
+				wetness = wetness + pee
+				pee = 0
+			else
+				wetness = 200 + heftersbonus
+				new /obj/effect/decal/cleanable/waste/peepee(loc)
+			if(max_wetcontinence > 25)
+				max_wetcontinence-=1
 
 		//finally, we want to display the actual pee flavortext
 		//
@@ -160,7 +157,7 @@ var/database/db = new("code/modules/incon/InconFlavortextDB.db")
 			//if the player is not fully incontinent, we call the proc to display the flavortext, specifying the sort of message we want to see
 			DisplayFlavortextMessage("peeaccident")
 
-		//at the end of things, we set the player's pee to zero, and clear the "on_purpose" flag
+		//Finally, regardless of if the player is on a toilet or not, we set pee to 0 and remove the on_purpose flag.
 		pee = 0
 		on_purpose = 0
 		//and thats the end of the pee action!
@@ -242,7 +239,7 @@ var/database/db = new("code/modules/incon/InconFlavortextDB.db")
 		if(poop > max_messcontinence)
 			poop = max_messcontinence
 
-		//if the player makes it to a potty or toilet, they are rewarded with an increase in their continence
+		//Next, if the player makes it to a potty or toilet, they are rewarded with an increase in their continence
 		if (istype(src.buckled,/obj/structure/potty) || istype(src.buckled,/obj/structure/toilet))
 			if (max_messcontinence < 100)
 				max_messcontinence++
@@ -251,36 +248,36 @@ var/database/db = new("code/modules/incon/InconFlavortextDB.db")
 				max_messcontinence-=2
 
 
-		//this block controls the state of your displayed clothing, and also diaper capacity
-		//which makes some sense, I guess
-		//I don't 100% understand this code, so I am commenting it less
-		if(ishuman(src))
-			var/mob/living/carbon/human/H = src
-			if((H.hidden_underwear == TRUE || H.underwear == "Nude") && !H.dna.features["taur"])
-				if(H.w_uniform != null)
-					H.w_uniform.soiled = TRUE
-					H.update_inv_w_uniform()
+			//this block controls the state of your displayed clothing, and also diaper capacity
+			//which makes some sense, I guess
+			//I don't 100% understand this code, so I am commenting it less
+			if(ishuman(src))
+				var/mob/living/carbon/human/H = src
+				if((H.hidden_underwear == TRUE || H.underwear == "Nude") && !H.dna.features["taur"])
+					if(H.w_uniform != null)
+						H.w_uniform.soiled = TRUE
+						H.update_inv_w_uniform()
+					else
+						if(H.wear_suit != null)
+							H.wear_suit.soiled = TRUE
+							H.update_inv_wear_suit()
+					poop = 0
+				if(stinkiness + poop < 150 + heftersbonus) //looks like 150 is the hardcoded default diaper capacity
+					stinkiness = stinkiness + poop
+					if(H.hidden_underwear == FALSE && H.underwear != "Nude")
+						H.soiledunderwear = TRUE
+						H.update_body()
 				else
-					if(H.wear_suit != null)
-						H.wear_suit.soiled = TRUE
-						H.update_inv_wear_suit()
-				poop = 0
-			if(stinkiness + poop < 150 + heftersbonus) //looks like 150 is the hardcoded default diaper capacity
-				stinkiness = stinkiness + poop
-				if(H.hidden_underwear == FALSE && H.underwear != "Nude")
-					H.soiledunderwear = TRUE
-					H.update_body()
-			else
-				stinkiness = 150 + heftersbonus
-				if(H.hidden_underwear == FALSE && H.underwear != "Nude")
-					H.soiledunderwear = TRUE
-					H.update_body()
+					stinkiness = 150 + heftersbonus
+					if(H.hidden_underwear == FALSE && H.underwear != "Nude")
+						H.soiledunderwear = TRUE
+						H.update_body()
 
-		//this block gives you stink lines if you don't already have them, and you meet the criteria
-		if(stinkiness > ((150 + heftersbonus) / 2) && stinky == FALSE)
-			statusoverlay = mutable_appearance('icons/incon/Effects.dmi',"generic_mob_stink",STINKLINES_LAYER, color = rgb(125, 241, 16))
-			overlays += statusoverlay
-			stinky = TRUE
+			//this block gives you stink lines if you don't already have them, and you meet the criteria
+			if(stinkiness > ((150 + heftersbonus) / 2) && stinky == FALSE)
+				statusoverlay = mutable_appearance('icons/incon/Effects.dmi',"generic_mob_stink",STINKLINES_LAYER, color = rgb(125, 241, 16))
+				overlays += statusoverlay
+				stinky = TRUE
 
 		//finally, we want to display the actual pee flavortext
 		//

--- a/code/modules/incon/reagents.dm
+++ b/code/modules/incon/reagents.dm
@@ -1,10 +1,13 @@
 // DIURETICS
 /datum/chemical_reaction/medicine/diuretic
-	results = list(/datum/reagent/medicine/diuretic = 10)
+	name = "Space Diuretics"
+	id = /datum/reagent/medicine/diuretic
+	results = list(/datum/reagent/medicine/diuretic = 4)
 	required_reagents = list(/datum/reagent/sulfur = 2, /datum/reagent/water = 1, /datum/reagent/consumable/sugar = 1)
 
 /datum/reagent/medicine/diuretic
 	name = "Space Diuretics"
+	description = "Fills the bladder to induce urinary relief."
 	taste_description = "water"
 	pH = 7.5
 	color = "#ccb464"
@@ -33,11 +36,14 @@
 
 // LAXATIVES
 /datum/chemical_reaction/medicine/laxative
+	name = "Space Lax"
+	id = /datum/reagent/medicine/laxative
 	results = list(/datum/reagent/medicine/laxative = 10)
 	required_reagents = list(/datum/reagent/carbon = 2, /datum/reagent/phenol = 3, /datum/reagent/nitrogen = 1, /datum/reagent/consumable/ethanol = 4)
 
 /datum/reagent/medicine/laxative
 	name = "Space Lax"
+	description = "Helps alleviate constipation, now 100% more effective than ancient Earth variants!"
 	taste_description = "charcoal"
 	pH = 7.5
 	color = "#543400"
@@ -60,20 +66,56 @@
 
 /datum/reagent/medicine/laxative/overdose_process(mob/living/carbon/M)
 	var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
-	if(L && prob(33))
-		L.applyOrganDamage(1)
+	if(L && prob(10))
+		L.applyOrganDamage(0.5)
 	if(prob(33))
 		M.Pooping()
 	..()
 	. = 1
 
+// Castor Oil
+/datum/chemical_reaction/medicine/castoroil
+	name = "Castor Oil"
+	id = /datum/reagent/medicine/castoroil
+	results = list(/datum/reagent/medicine/castoroil = 3)
+	required_reagents = list(/datum/reagent/medicine/laxative = 2, /datum/reagent/medicine/calomel = 1)
+
+/datum/reagent/medicine/castoroil
+	name = "Castor Oil"
+	description = "Quickly induces bowel movements, purging chemicals and minorly healing toxin damage. Has no effect on those immune to induced bowel activity."
+	taste_description = "indescribably horrible"
+	pH = 7.5
+	color = "#f8f89b"
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+
+/datum/reagent/medicine/castoroil/reaction_mob(mob/living/M, method=INGEST, reac_volume, show_message = 1) //eating castor oil will give you the grossed out moodlet
+	if(iscarbon(M) && M.stat != DEAD)
+		if(show_message)
+			to_chat(M, "<span class='warning'>That tasted awful!</span>")
+		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "gross_medicine", /datum/mood_event/gross_medicine)
+	..()
+
+/datum/reagent/medicine/castoroil/on_mob_life(mob/living/carbon/M)
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+	if(M.client.prefs.accident_types != "Pee Only" && src.volume >= 1)
+		M.poop += 1 * src.volume
+		M.adjustToxLoss(-1, FALSE)
+		for(var/A in M.reagents.reagent_list)
+			var/datum/reagent/R = A
+			if(R != src)
+				M.reagents.remove_reagent(R.type,2)
+	..()
+
 // REGRESSION SERUM
 /datum/chemical_reaction/medicine/regression
+	name = "Regression Serum"
+	id = /datum/reagent/medicine/regression
 	results = list(/datum/reagent/medicine/regression = 10)
 	required_reagents = list(/datum/reagent/medicine/omnizine = 3, /datum/reagent/toxin/carpotoxin = 2, /datum/reagent/ammonia = 5)
 
 /datum/reagent/medicine/regression
 	name = "Regression Serum"
+	description = "A solution that reduces one to an infantile state of mind."
 	taste_description = "childhood whimsy"
 	pH = 7.5
 	color = "#F034E2"
@@ -102,6 +144,31 @@
 		ADD_TRAIT(C, TRAIT_NORUNNING, ROUNDSTART_TRAIT)
 		ADD_TRAIT(C, TRAIT_NOGUNS, ROUNDSTART_TRAIT)
 		SEND_SIGNAL(C, COMSIG_DIAPERCHANGE, C.ckey)
+	return
+
+// Maturity Serum
+/datum/chemical_reaction/medicine/maturity
+	name = "Maturity Serum"
+	id = /datum/reagent/medicine/maturity
+	results = list(/datum/reagent/medicine/maturity = 2)
+	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/consumable/coffee = 1)
+
+/datum/reagent/medicine/maturity
+	name = "Maturity Serum"
+	description = "A serum that reverses the effects of Regression Serum overdose."
+	taste_description = "coffee and crushing disappointment"
+	pH = 7.5
+	color = "#504a41"
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+
+/datum/reagent/medicine/maturity/on_mob_add(mob/living/L)
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		L.reagents.remove_reagent(/datum/reagent/medicine/regression,3)
+		metabolization_rate = 0.1 * REAGENTS_METABOLISM
+		REMOVE_TRAIT(C, BABYBRAINED_TRAIT, ROUNDSTART_TRAIT)
+		REMOVE_TRAIT(C, TRAIT_NORUNNING, ROUNDSTART_TRAIT)
+		REMOVE_TRAIT(C, TRAIT_NOGUNS, ROUNDSTART_TRAIT)
 	return
 
 /datum/reagent/medicine/sodiumpolyacrylate


### PR DESCRIPTION
## About The Pull Request

Adds Castor Oil and Maturity Serum, and fixes the bug preventing players from using toilets correctly.

Castor Oil can be made by mixing Calomel and laxatives. Consuming castor oil will make the character suffer a negative moodlet from its awful taste, while purging chems and healing a tiny bit of damage. Castor Oil has no effect whatsoever if you do not have messing prefs enabled.
Maturity Serum is produced by mixing coffee and omnizine, and simply reverses the effects of a Regression Serum overdose while also purging Regression Serum.

## Why It's Good For The Game

Castor Oil allows for scenes wherein a character might be punished for REASONS with a nasty treat, while Maturity Serum allows for the treatment of players who have been overdosed on Regression Serum in case they didn't know what they were getting into.
As for the bug fix? Now I can play half my characters properly and enjoy quality scenes with them. uwu

## Changelog
:cl:
add: Added Castor Oil
add: Added Maturity Serum
fix: Using a toilet no longer makes you wet or mess yourself regardless.
/:cl: